### PR TITLE
Added 'actuator' capability

### DIFF
--- a/devicetypes/brbeaird/myq-garage-door-opener-nosensor.src/myq-garage-door-opener-nosensor.groovy
+++ b/devicetypes/brbeaird/myq-garage-door-opener-nosensor.src/myq-garage-door-opener-nosensor.groovy
@@ -19,6 +19,7 @@ metadata {
 	definition (name: "MyQ Garage Door Opener-NoSensor", namespace: "brbeaird", author: "Brian Beaird") {
 		capability "Garage Door Control"
 		capability "Door Control"
+		capability "Actuator"
         
         attribute "OpenButton", "string"
         attribute "CloseButton", "string"


### PR DESCRIPTION
Added the 'actuator' capability to the definition so the device handler can be used with SmartApps like the SharpTools.io dashboard which supports `Garage Door Control` and `Door Control` devices, but expects them to either be authorized along side the `contact` or `switch` capability... or will fall back to the `actuator` capability like this case.